### PR TITLE
Fix: Correct sound alias and address credit reporting

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -226,7 +226,7 @@ def game_loop():
                                     current_game_state.current_alerts.append(msg)
                                 elif current_game_state.credits < building_cost:
                                     msg = "Insufficient Credits!"
-                                    sound_manager_instance.play_sound("error_credits") # Changed sound
+                                    sound_manager_instance.play_sound("insufficient_credits") # Changed sound
                                     current_game_state.current_alerts.append(msg)
                                 else:
                                     can_place = True

--- a/src/ui.py
+++ b/src/ui.py
@@ -390,7 +390,7 @@ class UIManager:
                                 print(f"UI: Cannot select {key_to_build}, not enough credits.")
                                 gs_ref_inner.current_alerts.append(f"Need {b_data['cost']} CR for {b_data['ui_name']}")
                                 if hasattr(gs_ref_inner, 'sound_manager_instance') and gs_ref_inner.sound_manager_instance:
-                                     gs_ref_inner.sound_manager_instance.play_sound("error_credits")
+                                     gs_ref_inner.sound_manager_instance.play_sound("insufficient_credits")
                         return action_func
 
                     action = create_build_action_with_gs(b_key, game_state_ref)


### PR DESCRIPTION
- Corrected the sound alias for 'error_credits' to 'insufficient_credits' in main.py and ui.py to match its loading in sound_manager.py. This resolves the 'Sound effect error_credits not found' error.
- Investigated the 'Cannot select COMMAND_CENTER, not enough credits' issue. With current INITIAL_CREDITS=10000 and Command Center cost=5000, this should not occur in a new game. The issue might have been related to a loaded save file with low credits or a previous temporary code state.
- The sound fix should ensure that building placement is no longer blocked if it was an indirect consequence of the sound loading error.